### PR TITLE
Revert "Do not include `fsGroup` for nifi-registry by default"

### DIFF
--- a/charts/nifi_registry/values.yaml
+++ b/charts/nifi_registry/values.yaml
@@ -78,6 +78,7 @@ securityContext:
   runAsUser: 1000
   runAsGroup: 1000
   runAsNonRoot: true
+  fsGroup: 1000
 
 probeTimings:
   startup:


### PR DESCRIPTION
This reverts commit b73b395570d42ba7e951b692679f251bb04739d6.