### PR TITLE
Remove invalid pod certificate subject alt name

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.0
+version: 0.21.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nifi_registry/Chart.yaml
+++ b/charts/nifi_registry/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.0
+version: 0.21.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -81,7 +81,7 @@ Certificate subject alternative names
 {{- define "nifi.certificateSubjectAltNames" }}
 {{- $fullName := (include "nifi.fullname" . ) }}
 {{- $namespace := .Release.Namespace }}
-{{- printf "${POD_NAME}.%s.%s,%s-http.%s,%s" $fullName $namespace $fullName $namespace }}
+{{- printf "${POD_NAME}.%s.%s,%s-http.%s" $fullName $namespace $fullName $namespace }}
 {{- with .Values.tls.subjectAltNames }}
 {{- printf ",%s" (join "," .) }}
 {{- end }}


### PR DESCRIPTION
Pod certificates contain an invalid Subject Alt Name (SAN) entry, due to an incorrect format string: `%!s(MISSING)`.

This PR removes that invalid entry.